### PR TITLE
fix(cache2k): target correct access expiry time

### DIFF
--- a/provider-androidx/src/main/java/io/github/iprodigy/cache/provider/androidx/AndroidLruProvider.java
+++ b/provider-androidx/src/main/java/io/github/iprodigy/cache/provider/androidx/AndroidLruProvider.java
@@ -4,16 +4,23 @@ import androidx.collection.LruCache;
 import io.github.iprodigy.cache.api.Cache;
 import io.github.iprodigy.cache.api.ICacheSpec;
 import io.github.iprodigy.cache.api.RemovalListener;
+import io.github.iprodigy.cache.api.domain.ExpiryType;
 import io.github.iprodigy.cache.api.domain.RemovalCause;
 import io.github.iprodigy.cache.core.AbstractCacheProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public final class AndroidLruProvider extends AbstractCacheProvider {
+
 	@Override
 	public <K, V> Cache<K, V> build(ICacheSpec<K, V> spec) {
 		handleUnsupportedExpiry(spec.expiryTime());
 		return new LruDelegate<>(build(spec.maxSize(), spec.removalListener()));
+	}
+
+	@Override
+	protected ExpiryType preferredType() {
+		return null; // expiry is not supported by this provider
 	}
 
 	static <K, V> LruCache<K, V> build(Long maxSize, RemovalListener<K, V> listener) {
@@ -35,4 +42,5 @@ public final class AndroidLruProvider extends AbstractCacheProvider {
 			}
 		};
 	}
+
 }

--- a/provider-cache2k/src/main/java/io/github/iprodigy/cache/provider/cache2k/Cache2kProvider.java
+++ b/provider-cache2k/src/main/java/io/github/iprodigy/cache/provider/cache2k/Cache2kProvider.java
@@ -43,13 +43,18 @@ public final class Cache2kProvider extends AbstractCacheProvider {
 			if (type == ExpiryType.POST_WRITE)
 				builder.expireAfterWrite(time);
 			else
-				builder.idleScanTime(time);
+				builder.idleScanTime(Math.round(time.toNanos() / 3.0 * 2), TimeUnit.NANOSECONDS); // https://github.com/cache2k/cache2k/issues/39
 
 			if (exec != null)
 				builder.sharpExpiry(true);
 		});
 
 		return new Cache2kDelegate<>(builder.build());
+	}
+
+	@Override
+	protected ExpiryType preferredType() {
+		return ExpiryType.POST_WRITE; // POST_ACCESS isn't precisely offered out-of-the-box by cache2k
 	}
 
 	private static <K, V> ScheduledExecutorService populateExecutor(Cache2kBuilder<K, V> builder, ScheduledExecutorService exec) {


### PR DESCRIPTION
https://cache2k.org/docs/latest/apidocs/cache2k-api/org/cache2k/Cache2kBuilder.html#idleScanTime(java.time.Duration)